### PR TITLE
Add support for Juno NFTs and improve validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,105 @@ npm install
 ```
 npm run dev
 ```
+
+## Architecture
+
+### `GET /:publicKey`
+
+`publicKey` is the hexadecimal representation of a public key in the Cosmos.
+
+The returned type is:
+
+```ts
+type FetchProfileResponse = {
+  nonce: number;
+  name: string | null;
+  nft: {
+    chainId: string;
+    collectionAddress: string;
+    tokenId: string;
+    imageUrl: string;
+  } | null;
+};
+```
+
+or in the case of an error:
+
+```ts
+type FetchProfileResponse = {
+  error: string;
+  message: string;
+};
+```
+
+This route checks if profile information has been set for the given public key,
+verifies that the NFT is still owned by the public key, and verifies that the
+NFT has an image URL set. If the public key no longer owns the NFT, or there
+is no image URL set, the NFT is removed from the profile to prevent future
+unnecessary checks.
+
+The retrieval of the image URL depends on the chain:
+
+- For Stargaze, it is fetched from the Stargaze API.
+- For Juno, it queries the `nft_info` method on the smart contract of the NFT's
+  `collectionAddress`. If `extension` is present, it checks for `image`,
+  `image_uri`, and `image_url`, in that order. If any is present, it uses that
+  one. If not, it tries to fetch the data located at the URL provided by the
+  `token_uri` field. If this response is JSON, it assumes the data conforms to
+  the [ERC721 Metadata JSON
+  Schema](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md#specification)
+  standard, and uses the `image` field from that response. If the response is
+  not JSON, it just uses `token_uri` directly and hopes it is an image. Some
+  NFTs use that field for the image, and not all servers set the correct
+  mimetype headers (such as IPFS URLs that don't care about the contents of the
+  data).
+
+### `POST /:publicKey`
+
+`publicKey` is the hexadecimal representation of a public key in the Cosmos.
+
+The expected request body type is:
+
+```ts
+type UpdateProfileRequest = {
+  profile: {
+    nonce: number;
+    name?: string | null;
+    nft?: {
+      chainId: string;
+      collectionAddress: string;
+      tokenId: string;
+    } | null;
+  };
+  signature: string;
+  signer: string;
+};
+```
+
+The returned type is:
+
+```ts
+type UpdateProfileResponse = {
+  success: true;
+};
+```
+
+or in the case of an error:
+
+```ts
+type UpdateProfileResponse = {
+  error: string;
+  message: string;
+};
+```
+
+This route lets someone perform partial updates to their profile. If `name` or
+`nft` is `null`, that field is cleared. If either is `undefined` or omitted,
+nothing happens to that field.
+
+The nonce from the latest GET request must be provided to prevent replay
+attacks. It starts at 0, and the GET request will return an empty profile with a
+nonce of 0 if nothing has been set. The name must be unique, at least 1
+character long, and at most 32 characters long. The NFT must be owned by the
+public key, and the signature must be made by the same public key. If the NFT
+has no image, it will fail.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@cosmjs/amino": "^0.29.0",
+        "@cosmjs/cosmwasm-stargate": "^0.29.0",
         "@cosmjs/crypto": "^0.29.0",
         "@cosmjs/encoding": "^0.29.0",
         "crypto-js": "^4.1.1",
@@ -36,25 +37,52 @@
       "integrity": "sha512-gaBUSaKS65mN3iKZEgichbXYEmAa/pXkc5Gbt+1BptYphdGkj09ggdsiE4w8g0F/uI1g36QaTKrzVnBAWMipvQ==",
       "dev": true
     },
-    "node_modules/@cosmjs/amino": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.29.0.tgz",
-      "integrity": "sha512-/ZUVx6nRN5YE36H3SDq9+i8g2nZ8DJQnN9fVRC8rSHQKauNkoEuK4NxTNcQ2o2EBLUT0kyYAFY2550HVsPMrgw==",
+    "node_modules/@confio/ics23": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@confio/ics23/-/ics23-0.6.8.tgz",
+      "integrity": "sha512-wB6uo+3A50m0sW/EWcU64xpV/8wShZ6bMTa7pF8eYsTrSkQA7oLUIJcs/wb8g4y2Oyq701BaGiO6n/ak5WXO1w==",
       "dependencies": {
-        "@cosmjs/crypto": "^0.29.0",
-        "@cosmjs/encoding": "^0.29.0",
-        "@cosmjs/math": "^0.29.0",
-        "@cosmjs/utils": "^0.29.0"
+        "@noble/hashes": "^1.0.0",
+        "protobufjs": "^6.8.8"
+      }
+    },
+    "node_modules/@cosmjs/amino": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.29.2.tgz",
+      "integrity": "sha512-59Ta3liptOPPFNclziqaScm8Uvs5iwUkEU/Nl6SRMrmRU7lOdOYbNqsBgp27Ozc5jL2d8+ML4AyrJ1S5x8jgAw==",
+      "dependencies": {
+        "@cosmjs/crypto": "^0.29.2",
+        "@cosmjs/encoding": "^0.29.2",
+        "@cosmjs/math": "^0.29.2",
+        "@cosmjs/utils": "^0.29.2"
+      }
+    },
+    "node_modules/@cosmjs/cosmwasm-stargate": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/cosmwasm-stargate/-/cosmwasm-stargate-0.29.2.tgz",
+      "integrity": "sha512-NC3e0QOJR0iTpexPogEDiJgQ1HIIL6fahowLmmsTO60RbnARd/gEjf5AmdJ/6I8KigN8pSqQOr9Yvu6M73/9yg==",
+      "dependencies": {
+        "@cosmjs/amino": "^0.29.2",
+        "@cosmjs/crypto": "^0.29.2",
+        "@cosmjs/encoding": "^0.29.2",
+        "@cosmjs/math": "^0.29.2",
+        "@cosmjs/proto-signing": "^0.29.2",
+        "@cosmjs/stargate": "^0.29.2",
+        "@cosmjs/tendermint-rpc": "^0.29.2",
+        "@cosmjs/utils": "^0.29.2",
+        "cosmjs-types": "^0.5.2",
+        "long": "^4.0.0",
+        "pako": "^2.0.2"
       }
     },
     "node_modules/@cosmjs/crypto": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.29.0.tgz",
-      "integrity": "sha512-MPJoebRGh7AcZgbfR25ci7iV+XzJiKwVq4wL8n6M5P2QdrIv7DqqniyFXcBbn9dQjMLMHnOSgT9LRv+VXzUVCA==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.29.2.tgz",
+      "integrity": "sha512-mm4BNiuLAvfJOPYilP8uCs4MKJIogri2A5jb0xn+ZiyFTdIw6xp5eLU7SLxI/V+F2VMPfQDNfS+syPEkDN7g/w==",
       "dependencies": {
-        "@cosmjs/encoding": "^0.29.0",
-        "@cosmjs/math": "^0.29.0",
-        "@cosmjs/utils": "^0.29.0",
+        "@cosmjs/encoding": "^0.29.2",
+        "@cosmjs/math": "^0.29.2",
+        "@cosmjs/utils": "^0.29.2",
         "@noble/hashes": "^1",
         "bn.js": "^5.2.0",
         "elliptic": "^6.5.3",
@@ -62,27 +90,125 @@
       }
     },
     "node_modules/@cosmjs/encoding": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.29.0.tgz",
-      "integrity": "sha512-6HDBtid/YLbyXapY6PdMMIigAtGKyD1w0dUCLU1dOIkPf1q3y43kqoA7WnLkRw0g0/lZY1VGM2fX+2RWU0wxYg==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.29.2.tgz",
+      "integrity": "sha512-v62YsTVvDOSbSAHpD2u5oe0yk/ljitkgi+CM/hpL1qytaVKIlr1RSwBDhJ5cW11oqkIjMWM8UNsGeIG8lyt9JA==",
       "dependencies": {
         "base64-js": "^1.3.0",
         "bech32": "^1.1.4",
         "readonly-date": "^1.0.0"
       }
     },
+    "node_modules/@cosmjs/json-rpc": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.29.2.tgz",
+      "integrity": "sha512-oJA12dZflR/VU8zqiu+6gTt1SbKAhJSr/D5qAbIPdUcRzfI44J5h6tOvxnAuzJIig4oAid4u92KeuibAKFRJeA==",
+      "dependencies": {
+        "@cosmjs/stream": "^0.29.2",
+        "xstream": "^11.14.0"
+      }
+    },
     "node_modules/@cosmjs/math": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.29.0.tgz",
-      "integrity": "sha512-ufRRmyDQtJUrH8r1V4N7Q6rTOk9ZX7XIXjJto7cfXP8kcxm7IJXKYk+r0EfDnNHFkxTidYvW/1YXeeNoy8xZYw==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.29.2.tgz",
+      "integrity": "sha512-WhgvinqNauEG0GNF7OMNU/cWqBZQ537Zy5d6FAO1+5lOpLhxxBPshEJIO4l2VPU702/JcC5qa49AxyiV3JuGmA==",
       "dependencies": {
         "bn.js": "^5.2.0"
       }
     },
+    "node_modules/@cosmjs/proto-signing": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.29.2.tgz",
+      "integrity": "sha512-+YU1u/SVbvBTiWXkUPca/HNKChSOHuVMrWbhNOzEJgJphYVYwCXabpSFguCymJ1lOFwa0WXIykVqsIzQdEgMQw==",
+      "dependencies": {
+        "@cosmjs/amino": "^0.29.2",
+        "@cosmjs/crypto": "^0.29.2",
+        "@cosmjs/encoding": "^0.29.2",
+        "@cosmjs/math": "^0.29.2",
+        "@cosmjs/utils": "^0.29.2",
+        "cosmjs-types": "^0.5.2",
+        "long": "^4.0.0"
+      }
+    },
+    "node_modules/@cosmjs/socket": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.29.2.tgz",
+      "integrity": "sha512-SllIOXmn5x3wWfcknv5gmd25kNS2aJmiHEjOM1D+ZUACXzLZBqKTNolg5+8e0yVfR+4yxsJS9w5ocINrY6j0rA==",
+      "dependencies": {
+        "@cosmjs/stream": "^0.29.2",
+        "isomorphic-ws": "^4.0.1",
+        "ws": "^7",
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@cosmjs/socket/node_modules/ws": {
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cosmjs/stargate": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.29.2.tgz",
+      "integrity": "sha512-jCspWI+S+g1DE/rE8wR/JDzmeur120OOacinAADBKiHjSqu9R3qAaiC9kKPsQWl2PYk4qAs8sxLkjg+gq2vRGw==",
+      "dependencies": {
+        "@confio/ics23": "^0.6.8",
+        "@cosmjs/amino": "^0.29.2",
+        "@cosmjs/encoding": "^0.29.2",
+        "@cosmjs/math": "^0.29.2",
+        "@cosmjs/proto-signing": "^0.29.2",
+        "@cosmjs/stream": "^0.29.2",
+        "@cosmjs/tendermint-rpc": "^0.29.2",
+        "@cosmjs/utils": "^0.29.2",
+        "cosmjs-types": "^0.5.2",
+        "long": "^4.0.0",
+        "protobufjs": "~6.11.3",
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@cosmjs/stream": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.29.2.tgz",
+      "integrity": "sha512-ov0N6paYO1VVBl9gOu+i7RJyMR7wAWkN+xcxLN123+UHzRgTPWggJ18RqUCZ2Z87hKWHCkzD8pagi8Rf4uY7cg==",
+      "dependencies": {
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@cosmjs/tendermint-rpc": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.29.2.tgz",
+      "integrity": "sha512-l3SFzBhJwN5+7gg7elknSFhw1e+YN7QjVTanMZJ0hPH5njeIxaUkabk2y3fqWMBxoUkuCsmxJEIeCSByX/6R8A==",
+      "dependencies": {
+        "@cosmjs/crypto": "^0.29.2",
+        "@cosmjs/encoding": "^0.29.2",
+        "@cosmjs/json-rpc": "^0.29.2",
+        "@cosmjs/math": "^0.29.2",
+        "@cosmjs/socket": "^0.29.2",
+        "@cosmjs/stream": "^0.29.2",
+        "@cosmjs/utils": "^0.29.2",
+        "axios": "^0.21.2",
+        "readonly-date": "^1.0.0",
+        "xstream": "^11.14.0"
+      }
+    },
     "node_modules/@cosmjs/utils": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.29.0.tgz",
-      "integrity": "sha512-NiJk3ISX+FU1cQcTTgmJcY84A8mV/p8L5CRewp/2jc/lUmo8j9lMGbX17U7NxVQ9RX5RmrwgdjYnBASzhRCVmA=="
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.29.2.tgz",
+      "integrity": "sha512-gckp8mbNXF8XCAEwCzH90fpaA0K2O9CC5Rg5v75zsRySYkAaoJIm9f+f8yW2qn6ADge2BnmIT1IkAfmswThCJQ=="
     },
     "node_modules/@esbuild-plugins/node-globals-polyfill": {
       "version": "0.1.1",
@@ -378,6 +504,60 @@
         }
       ]
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.0.tgz",
@@ -393,11 +573,15 @@
       "integrity": "sha512-BG7fQKZ689HIoc5h+6D2Dgq1fABRa0RbBWKBd9SP/MVRVXROflpm5fhwyATX5duFmbStzyzyycPB8qUYKDH3NA==",
       "dev": true
     },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
+    },
     "node_modules/@types/node": {
       "version": "18.8.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.2.tgz",
-      "integrity": "sha512-cRMwIgdDN43GO4xMWAfJAecYn8wV4JbsOGHNfNUIDiuYkUYAR5ec4Rj7IO2SAhFPEfpPtLtUTbbny/TCT7aDwA==",
-      "dev": true
+      "integrity": "sha512-cRMwIgdDN43GO4xMWAfJAecYn8wV4JbsOGHNfNUIDiuYkUYAR5ec4Rj7IO2SAhFPEfpPtLtUTbbny/TCT7aDwA=="
     },
     "node_modules/@types/stack-trace": {
       "version": "0.0.29",
@@ -416,6 +600,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/base64-js": {
@@ -542,6 +734,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cosmjs-types": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.5.2.tgz",
+      "integrity": "sha512-zxCtIJj8v3Di7s39uN4LNcN3HIE1z0B9Z0SPE8ZNQR0oSzsuSe1ACgxoFkvhkS7WBasCAFcglS11G2hyfd5tPg==",
+      "dependencies": {
+        "long": "^4.0.0",
+        "protobufjs": "~6.11.2"
+      }
+    },
     "node_modules/cron-schedule": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/cron-schedule/-/cron-schedule-3.0.6.tgz",
@@ -566,6 +767,21 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
       "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
+    },
+    "node_modules/define-properties": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+      "dependencies": {
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/dotenv": {
       "version": "10.0.0",
@@ -1003,6 +1219,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -1015,6 +1250,24 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-stream": {
@@ -1039,6 +1292,53 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "dependencies": {
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dependencies": {
+        "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hash.js": {
@@ -1146,6 +1446,14 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/itty-cors": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/itty-cors/-/itty-cors-0.2.2.tgz",
@@ -1177,6 +1485,11 @@
       "dependencies": {
         "libsodium": "^0.7.0"
       }
+    },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -1368,6 +1681,14 @@
         "validate-npm-package-name": "^4.0.0"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/onetime": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
@@ -1382,6 +1703,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
     },
     "node_modules/parse-package-name": {
       "version": "1.0.0",
@@ -1414,6 +1740,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
       }
     },
     "node_modules/readdirp": {
@@ -1596,6 +1947,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/symbol-observable": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-2.0.3.tgz",
+      "integrity": "sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA==",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -1687,7 +2046,6 @@
       "version": "8.9.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
       "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
-      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1702,6 +2060,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xstream": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/xstream/-/xstream-11.14.0.tgz",
+      "integrity": "sha512-1bLb+kKKtKPbgTK6i/BaoAn03g47PpFstlbe1BA+y3pNS/LfvcaghS5BFf9+EE1J+KwSQsEpfJvFN5GqFtiNmw==",
+      "dependencies": {
+        "globalthis": "^1.0.1",
+        "symbol-observable": "^2.0.3"
       }
     },
     "node_modules/xxhash-wasm": {
@@ -1745,25 +2112,52 @@
       "integrity": "sha512-gaBUSaKS65mN3iKZEgichbXYEmAa/pXkc5Gbt+1BptYphdGkj09ggdsiE4w8g0F/uI1g36QaTKrzVnBAWMipvQ==",
       "dev": true
     },
-    "@cosmjs/amino": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.29.0.tgz",
-      "integrity": "sha512-/ZUVx6nRN5YE36H3SDq9+i8g2nZ8DJQnN9fVRC8rSHQKauNkoEuK4NxTNcQ2o2EBLUT0kyYAFY2550HVsPMrgw==",
+    "@confio/ics23": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@confio/ics23/-/ics23-0.6.8.tgz",
+      "integrity": "sha512-wB6uo+3A50m0sW/EWcU64xpV/8wShZ6bMTa7pF8eYsTrSkQA7oLUIJcs/wb8g4y2Oyq701BaGiO6n/ak5WXO1w==",
       "requires": {
-        "@cosmjs/crypto": "^0.29.0",
-        "@cosmjs/encoding": "^0.29.0",
-        "@cosmjs/math": "^0.29.0",
-        "@cosmjs/utils": "^0.29.0"
+        "@noble/hashes": "^1.0.0",
+        "protobufjs": "^6.8.8"
+      }
+    },
+    "@cosmjs/amino": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.29.2.tgz",
+      "integrity": "sha512-59Ta3liptOPPFNclziqaScm8Uvs5iwUkEU/Nl6SRMrmRU7lOdOYbNqsBgp27Ozc5jL2d8+ML4AyrJ1S5x8jgAw==",
+      "requires": {
+        "@cosmjs/crypto": "^0.29.2",
+        "@cosmjs/encoding": "^0.29.2",
+        "@cosmjs/math": "^0.29.2",
+        "@cosmjs/utils": "^0.29.2"
+      }
+    },
+    "@cosmjs/cosmwasm-stargate": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/cosmwasm-stargate/-/cosmwasm-stargate-0.29.2.tgz",
+      "integrity": "sha512-NC3e0QOJR0iTpexPogEDiJgQ1HIIL6fahowLmmsTO60RbnARd/gEjf5AmdJ/6I8KigN8pSqQOr9Yvu6M73/9yg==",
+      "requires": {
+        "@cosmjs/amino": "^0.29.2",
+        "@cosmjs/crypto": "^0.29.2",
+        "@cosmjs/encoding": "^0.29.2",
+        "@cosmjs/math": "^0.29.2",
+        "@cosmjs/proto-signing": "^0.29.2",
+        "@cosmjs/stargate": "^0.29.2",
+        "@cosmjs/tendermint-rpc": "^0.29.2",
+        "@cosmjs/utils": "^0.29.2",
+        "cosmjs-types": "^0.5.2",
+        "long": "^4.0.0",
+        "pako": "^2.0.2"
       }
     },
     "@cosmjs/crypto": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.29.0.tgz",
-      "integrity": "sha512-MPJoebRGh7AcZgbfR25ci7iV+XzJiKwVq4wL8n6M5P2QdrIv7DqqniyFXcBbn9dQjMLMHnOSgT9LRv+VXzUVCA==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.29.2.tgz",
+      "integrity": "sha512-mm4BNiuLAvfJOPYilP8uCs4MKJIogri2A5jb0xn+ZiyFTdIw6xp5eLU7SLxI/V+F2VMPfQDNfS+syPEkDN7g/w==",
       "requires": {
-        "@cosmjs/encoding": "^0.29.0",
-        "@cosmjs/math": "^0.29.0",
-        "@cosmjs/utils": "^0.29.0",
+        "@cosmjs/encoding": "^0.29.2",
+        "@cosmjs/math": "^0.29.2",
+        "@cosmjs/utils": "^0.29.2",
         "@noble/hashes": "^1",
         "bn.js": "^5.2.0",
         "elliptic": "^6.5.3",
@@ -1771,27 +2165,113 @@
       }
     },
     "@cosmjs/encoding": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.29.0.tgz",
-      "integrity": "sha512-6HDBtid/YLbyXapY6PdMMIigAtGKyD1w0dUCLU1dOIkPf1q3y43kqoA7WnLkRw0g0/lZY1VGM2fX+2RWU0wxYg==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.29.2.tgz",
+      "integrity": "sha512-v62YsTVvDOSbSAHpD2u5oe0yk/ljitkgi+CM/hpL1qytaVKIlr1RSwBDhJ5cW11oqkIjMWM8UNsGeIG8lyt9JA==",
       "requires": {
         "base64-js": "^1.3.0",
         "bech32": "^1.1.4",
         "readonly-date": "^1.0.0"
       }
     },
+    "@cosmjs/json-rpc": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.29.2.tgz",
+      "integrity": "sha512-oJA12dZflR/VU8zqiu+6gTt1SbKAhJSr/D5qAbIPdUcRzfI44J5h6tOvxnAuzJIig4oAid4u92KeuibAKFRJeA==",
+      "requires": {
+        "@cosmjs/stream": "^0.29.2",
+        "xstream": "^11.14.0"
+      }
+    },
     "@cosmjs/math": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.29.0.tgz",
-      "integrity": "sha512-ufRRmyDQtJUrH8r1V4N7Q6rTOk9ZX7XIXjJto7cfXP8kcxm7IJXKYk+r0EfDnNHFkxTidYvW/1YXeeNoy8xZYw==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.29.2.tgz",
+      "integrity": "sha512-WhgvinqNauEG0GNF7OMNU/cWqBZQ537Zy5d6FAO1+5lOpLhxxBPshEJIO4l2VPU702/JcC5qa49AxyiV3JuGmA==",
       "requires": {
         "bn.js": "^5.2.0"
       }
     },
+    "@cosmjs/proto-signing": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.29.2.tgz",
+      "integrity": "sha512-+YU1u/SVbvBTiWXkUPca/HNKChSOHuVMrWbhNOzEJgJphYVYwCXabpSFguCymJ1lOFwa0WXIykVqsIzQdEgMQw==",
+      "requires": {
+        "@cosmjs/amino": "^0.29.2",
+        "@cosmjs/crypto": "^0.29.2",
+        "@cosmjs/encoding": "^0.29.2",
+        "@cosmjs/math": "^0.29.2",
+        "@cosmjs/utils": "^0.29.2",
+        "cosmjs-types": "^0.5.2",
+        "long": "^4.0.0"
+      }
+    },
+    "@cosmjs/socket": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.29.2.tgz",
+      "integrity": "sha512-SllIOXmn5x3wWfcknv5gmd25kNS2aJmiHEjOM1D+ZUACXzLZBqKTNolg5+8e0yVfR+4yxsJS9w5ocINrY6j0rA==",
+      "requires": {
+        "@cosmjs/stream": "^0.29.2",
+        "isomorphic-ws": "^4.0.1",
+        "ws": "^7",
+        "xstream": "^11.14.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "7.5.9",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+          "requires": {}
+        }
+      }
+    },
+    "@cosmjs/stargate": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.29.2.tgz",
+      "integrity": "sha512-jCspWI+S+g1DE/rE8wR/JDzmeur120OOacinAADBKiHjSqu9R3qAaiC9kKPsQWl2PYk4qAs8sxLkjg+gq2vRGw==",
+      "requires": {
+        "@confio/ics23": "^0.6.8",
+        "@cosmjs/amino": "^0.29.2",
+        "@cosmjs/encoding": "^0.29.2",
+        "@cosmjs/math": "^0.29.2",
+        "@cosmjs/proto-signing": "^0.29.2",
+        "@cosmjs/stream": "^0.29.2",
+        "@cosmjs/tendermint-rpc": "^0.29.2",
+        "@cosmjs/utils": "^0.29.2",
+        "cosmjs-types": "^0.5.2",
+        "long": "^4.0.0",
+        "protobufjs": "~6.11.3",
+        "xstream": "^11.14.0"
+      }
+    },
+    "@cosmjs/stream": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.29.2.tgz",
+      "integrity": "sha512-ov0N6paYO1VVBl9gOu+i7RJyMR7wAWkN+xcxLN123+UHzRgTPWggJ18RqUCZ2Z87hKWHCkzD8pagi8Rf4uY7cg==",
+      "requires": {
+        "xstream": "^11.14.0"
+      }
+    },
+    "@cosmjs/tendermint-rpc": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.29.2.tgz",
+      "integrity": "sha512-l3SFzBhJwN5+7gg7elknSFhw1e+YN7QjVTanMZJ0hPH5njeIxaUkabk2y3fqWMBxoUkuCsmxJEIeCSByX/6R8A==",
+      "requires": {
+        "@cosmjs/crypto": "^0.29.2",
+        "@cosmjs/encoding": "^0.29.2",
+        "@cosmjs/json-rpc": "^0.29.2",
+        "@cosmjs/math": "^0.29.2",
+        "@cosmjs/socket": "^0.29.2",
+        "@cosmjs/stream": "^0.29.2",
+        "@cosmjs/utils": "^0.29.2",
+        "axios": "^0.21.2",
+        "readonly-date": "^1.0.0",
+        "xstream": "^11.14.0"
+      }
+    },
     "@cosmjs/utils": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.29.0.tgz",
-      "integrity": "sha512-NiJk3ISX+FU1cQcTTgmJcY84A8mV/p8L5CRewp/2jc/lUmo8j9lMGbX17U7NxVQ9RX5RmrwgdjYnBASzhRCVmA=="
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.29.2.tgz",
+      "integrity": "sha512-gckp8mbNXF8XCAEwCzH90fpaA0K2O9CC5Rg5v75zsRySYkAaoJIm9f+f8yW2qn6ADge2BnmIT1IkAfmswThCJQ=="
     },
     "@esbuild-plugins/node-globals-polyfill": {
       "version": "0.1.1",
@@ -2022,6 +2502,60 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.3.tgz",
       "integrity": "sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A=="
     },
+    "@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+    },
+    "@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
     "@types/better-sqlite3": {
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.0.tgz",
@@ -2037,11 +2571,15 @@
       "integrity": "sha512-BG7fQKZ689HIoc5h+6D2Dgq1fABRa0RbBWKBd9SP/MVRVXROflpm5fhwyATX5duFmbStzyzyycPB8qUYKDH3NA==",
       "dev": true
     },
+    "@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
+    },
     "@types/node": {
       "version": "18.8.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.2.tgz",
-      "integrity": "sha512-cRMwIgdDN43GO4xMWAfJAecYn8wV4JbsOGHNfNUIDiuYkUYAR5ec4Rj7IO2SAhFPEfpPtLtUTbbny/TCT7aDwA==",
-      "dev": true
+      "integrity": "sha512-cRMwIgdDN43GO4xMWAfJAecYn8wV4JbsOGHNfNUIDiuYkUYAR5ec4Rj7IO2SAhFPEfpPtLtUTbbny/TCT7aDwA=="
     },
     "@types/stack-trace": {
       "version": "0.0.29",
@@ -2057,6 +2595,14 @@
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
+      }
+    },
+    "axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "requires": {
+        "follow-redirects": "^1.14.0"
       }
     },
     "base64-js": {
@@ -2146,6 +2692,15 @@
       "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
       "dev": true
     },
+    "cosmjs-types": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.5.2.tgz",
+      "integrity": "sha512-zxCtIJj8v3Di7s39uN4LNcN3HIE1z0B9Z0SPE8ZNQR0oSzsuSe1ACgxoFkvhkS7WBasCAFcglS11G2hyfd5tPg==",
+      "requires": {
+        "long": "^4.0.0",
+        "protobufjs": "~6.11.2"
+      }
+    },
     "cron-schedule": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/cron-schedule/-/cron-schedule-3.0.6.tgz",
@@ -2167,6 +2722,15 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
       "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
+    },
+    "define-properties": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+      "requires": {
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      }
     },
     "dotenv": {
       "version": "10.0.0",
@@ -2401,12 +2965,32 @@
         "to-regex-range": "^5.0.1"
       }
     },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+    },
     "fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "get-intrinsic": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.3"
+      }
     },
     "get-stream": {
       "version": "6.0.1",
@@ -2422,6 +3006,35 @@
       "requires": {
         "is-glob": "^4.0.1"
       }
+    },
+    "globalthis": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "requires": {
+        "define-properties": "^1.1.3"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "requires": {
+        "get-intrinsic": "^1.1.1"
+      }
+    },
+    "has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
     },
     "hash.js": {
       "version": "1.1.7",
@@ -2507,6 +3120,12 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "requires": {}
+    },
     "itty-cors": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/itty-cors/-/itty-cors-0.2.2.tgz",
@@ -2535,6 +3154,11 @@
       "requires": {
         "libsodium": "^0.7.0"
       }
+    },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -2664,6 +3288,11 @@
         "validate-npm-package-name": "^4.0.0"
       }
     },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+    },
     "onetime": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
@@ -2672,6 +3301,11 @@
       "requires": {
         "mimic-fn": "^4.0.0"
       }
+    },
+    "pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
     },
     "parse-package-name": {
       "version": "1.0.0",
@@ -2696,6 +3330,26 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
+    },
+    "protobufjs": {
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      }
     },
     "readdirp": {
       "version": "3.6.0",
@@ -2839,6 +3493,11 @@
       "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
       "dev": true
     },
+    "symbol-observable": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-2.0.3.tgz",
+      "integrity": "sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA=="
+    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2906,8 +3565,16 @@
       "version": "8.9.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
       "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
-      "dev": true,
       "requires": {}
+    },
+    "xstream": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/xstream/-/xstream-11.14.0.tgz",
+      "integrity": "sha512-1bLb+kKKtKPbgTK6i/BaoAn03g47PpFstlbe1BA+y3pNS/LfvcaghS5BFf9+EE1J+KwSQsEpfJvFN5GqFtiNmw==",
+      "requires": {
+        "globalthis": "^1.0.1",
+        "symbol-observable": "^2.0.3"
+      }
     },
     "xxhash-wasm": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@cosmjs/amino": "^0.29.0",
+    "@cosmjs/cosmwasm-stargate": "^0.29.0",
     "@cosmjs/crypto": "^0.29.0",
     "@cosmjs/encoding": "^0.29.0",
     "crypto-js": "^4.1.1",

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -1,0 +1,21 @@
+import { JUNO_CHAIN_ID, STARGAZE_CHAIN_ID } from "../constants";
+import { VerificationError, GetOwnedNftImageUrlFunction } from "../types";
+import { getOwnedNftImageUrl as stargaze } from "./stargaze";
+import { getOwnedNftImageUrl as juno } from "./juno";
+
+const CHAINS: Record<string, GetOwnedNftImageUrlFunction | undefined> = {
+  [STARGAZE_CHAIN_ID]: stargaze,
+  [JUNO_CHAIN_ID]: juno,
+};
+
+export const getOwnedNftImageUrl = async (
+  chainId: string,
+  ...params: Parameters<GetOwnedNftImageUrlFunction>
+): ReturnType<GetOwnedNftImageUrlFunction> => {
+  const fn = CHAINS[chainId];
+  if (!fn) {
+    throw new VerificationError(400, "Invalid chain ID.");
+  }
+
+  return await fn(...params);
+};

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -1,5 +1,6 @@
 import { JUNO_CHAIN_ID, STARGAZE_CHAIN_ID } from "../constants";
-import { VerificationError, GetOwnedNftImageUrlFunction } from "../types";
+import { GetOwnedNftImageUrlFunction } from "../types";
+import { KnownError } from "../error";
 import { getOwnedNftImageUrl as stargaze } from "./stargaze";
 import { getOwnedNftImageUrl as juno } from "./juno";
 
@@ -14,7 +15,7 @@ export const getOwnedNftImageUrl = async (
 ): ReturnType<GetOwnedNftImageUrlFunction> => {
   const fn = CHAINS[chainId];
   if (!fn) {
-    throw new VerificationError(400, "Invalid chain ID.");
+    throw new KnownError(400, "Invalid chain ID.");
   }
 
   return await fn(...params);

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -15,7 +15,11 @@ export const getOwnedNftImageUrl = async (
 ): ReturnType<GetOwnedNftImageUrlFunction> => {
   const fn = CHAINS[chainId];
   if (!fn) {
-    throw new KnownError(400, "Invalid chain ID.");
+    throw new KnownError(
+      400,
+      "Invalid chain ID",
+      `Chain ID must be one of: ${Object.keys(CHAINS).join(", ")}`
+    );
   }
 
   return await fn(...params);

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -4,7 +4,7 @@ import { KnownError } from "../error";
 import { getOwnedNftImageUrl as stargaze } from "./stargaze";
 import { getOwnedNftImageUrl as juno } from "./juno";
 
-const CHAINS: Record<string, GetOwnedNftImageUrlFunction | undefined> = {
+export const CHAINS: Record<string, GetOwnedNftImageUrlFunction | undefined> = {
   [STARGAZE_CHAIN_ID]: stargaze,
   [JUNO_CHAIN_ID]: juno,
 };

--- a/src/chains/juno.ts
+++ b/src/chains/juno.ts
@@ -44,14 +44,5 @@ export const getOwnedNftImageUrl: GetOwnedNftImageUrlFunction = async (
     );
   }
 
-  // If image is empty, cannot be used as profile picture.
-  if (!imageUrl) {
-    throw new KnownError(
-      415,
-      "Invalid NFT data.",
-      "Failed to retrieve image data from NFT."
-    );
-  }
-
   return imageUrl;
 };

--- a/src/chains/juno.ts
+++ b/src/chains/juno.ts
@@ -16,7 +16,7 @@ export const getOwnedNftImageUrl: GetOwnedNftImageUrlFunction = async (
     junoAddress = secp256k1PublicKeyToBech32Address(publicKey, "juno");
   } catch (err) {
     console.error("PK to Address", err);
-    throw new KnownError(400, "Invalid public key.", err);
+    throw new KnownError(400, "Invalid public key", err);
   }
 
   let imageUrl: string | undefined;
@@ -39,7 +39,7 @@ export const getOwnedNftImageUrl: GetOwnedNftImageUrlFunction = async (
     console.error(err);
     throw new KnownError(
       500,
-      "Unexpected error retrieving NFT info from chain.",
+      "Unexpected error retrieving NFT info from chain",
       err
     );
   }

--- a/src/chains/juno.ts
+++ b/src/chains/juno.ts
@@ -1,0 +1,55 @@
+import { CosmWasmClient } from "@cosmjs/cosmwasm-stargate";
+import { VerificationError, GetOwnedNftImageUrlFunction } from "../types";
+import { secp256k1PublicKeyToBech32Address } from "../utils";
+import * as Cw721 from "../cw721";
+
+const JUNO_RPC = "https://rpc.juno.strange.love:443";
+
+export const getOwnedNftImageUrl: GetOwnedNftImageUrlFunction = async (
+  publicKey,
+  collectionAddress,
+  tokenId
+) => {
+  let junoAddress;
+  try {
+    junoAddress = secp256k1PublicKeyToBech32Address(publicKey, "juno");
+  } catch (err) {
+    console.error("PK to Address", err);
+    throw new VerificationError(400, "Invalid public key.", err);
+  }
+
+  let imageUrl: string | undefined;
+  try {
+    const client = await CosmWasmClient.connect(JUNO_RPC);
+
+    const owner = await Cw721.getOwner(client, collectionAddress, tokenId);
+    // If does not own NFT, return null.
+    if (owner.owner !== junoAddress) {
+      return null;
+    }
+
+    imageUrl = await Cw721.getImageUrl(client, collectionAddress, tokenId);
+  } catch (err) {
+    // If error already handled, pass up the chain.
+    if (err instanceof VerificationError) {
+      throw err;
+    }
+
+    console.error(err);
+    throw new VerificationError(
+      500,
+      "Unexpected error retrieving NFT info from chain.",
+      err
+    );
+  }
+
+  if (!imageUrl) {
+    throw new VerificationError(
+      415,
+      "Invalid NFT data.",
+      "Failed to retrieve image data from NFT."
+    );
+  }
+
+  return imageUrl;
+};

--- a/src/chains/juno.ts
+++ b/src/chains/juno.ts
@@ -1,9 +1,6 @@
 import { CosmWasmClient } from "@cosmjs/cosmwasm-stargate";
-import {
-  VerificationError,
-  GetOwnedNftImageUrlFunction,
-  NotOwnerError,
-} from "../types";
+import { GetOwnedNftImageUrlFunction } from "../types";
+import { KnownError, NotOwnerError } from "../error";
 import { secp256k1PublicKeyToBech32Address } from "../utils";
 import * as Cw721 from "../cw721";
 
@@ -19,7 +16,7 @@ export const getOwnedNftImageUrl: GetOwnedNftImageUrlFunction = async (
     junoAddress = secp256k1PublicKeyToBech32Address(publicKey, "juno");
   } catch (err) {
     console.error("PK to Address", err);
-    throw new VerificationError(400, "Invalid public key.", err);
+    throw new KnownError(400, "Invalid public key.", err);
   }
 
   let imageUrl: string | undefined;
@@ -35,12 +32,12 @@ export const getOwnedNftImageUrl: GetOwnedNftImageUrlFunction = async (
     imageUrl = await Cw721.getImageUrl(client, collectionAddress, tokenId);
   } catch (err) {
     // If error already handled, pass up the chain.
-    if (err instanceof VerificationError || err instanceof NotOwnerError) {
+    if (err instanceof KnownError || err instanceof NotOwnerError) {
       throw err;
     }
 
     console.error(err);
-    throw new VerificationError(
+    throw new KnownError(
       500,
       "Unexpected error retrieving NFT info from chain.",
       err
@@ -49,7 +46,7 @@ export const getOwnedNftImageUrl: GetOwnedNftImageUrlFunction = async (
 
   // If image is empty, cannot be used as profile picture.
   if (!imageUrl) {
-    throw new VerificationError(
+    throw new KnownError(
       415,
       "Invalid NFT data.",
       "Failed to retrieve image data from NFT."

--- a/src/chains/stargaze.ts
+++ b/src/chains/stargaze.ts
@@ -1,8 +1,5 @@
-import {
-  VerificationError,
-  GetOwnedNftImageUrlFunction,
-  NotOwnerError,
-} from "../types";
+import { GetOwnedNftImageUrlFunction } from "../types";
+import { KnownError, NotOwnerError } from "../error";
 import { secp256k1PublicKeyToBech32Address } from "../utils";
 
 const STARGAZE_API_TEMPLATE =
@@ -28,7 +25,7 @@ export const getOwnedNftImageUrl: GetOwnedNftImageUrlFunction = async (
     stargazeAddress = secp256k1PublicKeyToBech32Address(publicKey, "stars");
   } catch (err) {
     console.error("PK to Address", err);
-    throw new VerificationError(400, "Invalid public key.", err);
+    throw new KnownError(400, "Invalid public key.", err);
   }
 
   // Search Stargaze API for this address's NFTs. If the desired NFT is not
@@ -50,7 +47,7 @@ export const getOwnedNftImageUrl: GetOwnedNftImageUrlFunction = async (
 
   // If image is empty, cannot be used as profile picture.
   if (!stargazeNft.image) {
-    throw new VerificationError(
+    throw new KnownError(
       415,
       "Invalid NFT data.",
       "Failed to retrieve image data from NFT."

--- a/src/chains/stargaze.ts
+++ b/src/chains/stargaze.ts
@@ -45,14 +45,5 @@ export const getOwnedNftImageUrl: GetOwnedNftImageUrlFunction = async (
     throw new NotOwnerError();
   }
 
-  // If image is empty, cannot be used as profile picture.
-  if (!stargazeNft.image) {
-    throw new KnownError(
-      415,
-      "Invalid NFT data.",
-      "Failed to retrieve image data from NFT."
-    );
-  }
-
   return stargazeNft.image;
 };

--- a/src/chains/stargaze.ts
+++ b/src/chains/stargaze.ts
@@ -1,0 +1,52 @@
+import { VerificationError, GetOwnedNftImageUrlFunction } from "../types";
+import { secp256k1PublicKeyToBech32Address } from "../utils";
+
+const STARGAZE_API_TEMPLATE =
+  "https://nft-api.stargaze-apis.com/api/v1beta/profile/{{address}}/nfts";
+
+// Stargaze API NFT object.
+// The Stargaze API returns more data. These are the only fields we care about.
+interface StargazeNft {
+  image: string;
+  tokenId: string;
+  collection: {
+    contractAddress: string;
+  };
+}
+
+export const getOwnedNftImageUrl: GetOwnedNftImageUrlFunction = async (
+  publicKey,
+  collectionAddress,
+  tokenId
+) => {
+  let stargazeAddress;
+  try {
+    stargazeAddress = secp256k1PublicKeyToBech32Address(publicKey, "stars");
+  } catch (err) {
+    console.error("PK to Address", err);
+    throw new VerificationError(400, "Invalid public key.", err);
+  }
+
+  // Search Stargaze API for this address's NFT. If not present, public key does
+  // not own this NFT.
+  const stargazeNfts: StargazeNft[] = await (
+    await fetch(STARGAZE_API_TEMPLATE.replace("{{address}}", stargazeAddress))
+  ).json();
+
+  const stargazeNft =
+    stargazeNfts.find(
+      (stargazeNft) =>
+        stargazeNft.collection.contractAddress === collectionAddress &&
+        stargazeNft.tokenId === tokenId
+    );
+
+  if (!stargazeNft?.image) {
+    throw new VerificationError(
+      415,
+      "Invalid NFT data.",
+      "Failed to retrieve image data from NFT."
+    );
+  }
+
+  return stargazeNft.image;
+};

--- a/src/chains/stargaze.ts
+++ b/src/chains/stargaze.ts
@@ -25,7 +25,7 @@ export const getOwnedNftImageUrl: GetOwnedNftImageUrlFunction = async (
     stargazeAddress = secp256k1PublicKeyToBech32Address(publicKey, "stars");
   } catch (err) {
     console.error("PK to Address", err);
-    throw new KnownError(400, "Invalid public key.", err);
+    throw new KnownError(400, "Invalid public key", err);
   }
 
   // Search Stargaze API for this address's NFTs. If the desired NFT is not

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,2 @@
+export const STARGAZE_CHAIN_ID = "stargaze-1";
+export const JUNO_CHAIN_ID = "juno-1";

--- a/src/cw721.ts
+++ b/src/cw721.ts
@@ -1,5 +1,6 @@
 import { CosmWasmClient } from "@cosmjs/cosmwasm-stargate";
-import { Nft, VerificationError } from "./types";
+import { KnownError } from "./error";
+import { transformIpfsUrlToHttpsIfNecessary } from "./utils";
 
 type Expiration =
   | {
@@ -104,7 +105,7 @@ export const getImageUrl = async (
           }
         } catch (err) {
           console.error(err);
-          throw new VerificationError(
+          throw new KnownError(
             415,
             "Invalid NFT data.",
             "Failed to parse token_uri data as JSON."
@@ -116,12 +117,12 @@ export const getImageUrl = async (
       }
     } catch (err) {
       // If error already handled, pass up the chain.
-      if (err instanceof VerificationError) {
+      if (err instanceof KnownError) {
         throw err;
       }
 
       console.error(err);
-      throw new VerificationError(
+      throw new KnownError(
         500,
         "Unexpected error retrieving token_uri data.",
         err
@@ -131,9 +132,3 @@ export const getImageUrl = async (
 
   return imageUrl;
 };
-
-// Use Stargaze's IPFS gateway.
-const transformIpfsUrlToHttpsIfNecessary = (ipfsUrl: string) =>
-  ipfsUrl.startsWith("ipfs://")
-    ? ipfsUrl.replace("ipfs://", "https://ipfs.stargaze.zone/ipfs/")
-    : ipfsUrl;

--- a/src/cw721.ts
+++ b/src/cw721.ts
@@ -94,7 +94,7 @@ export const getImageUrl = async (
           console.error(err);
           throw new KnownError(
             415,
-            "Invalid NFT data.",
+            "Invalid NFT data",
             "Failed to parse token_uri data as JSON."
           );
         }
@@ -111,7 +111,7 @@ export const getImageUrl = async (
       console.error(err);
       throw new KnownError(
         500,
-        "Unexpected error retrieving token_uri data.",
+        "Unexpected error retrieving token_uri data",
         err
       );
     }

--- a/src/cw721.ts
+++ b/src/cw721.ts
@@ -1,0 +1,144 @@
+import { CosmWasmClient } from "@cosmjs/cosmwasm-stargate";
+import { VerificationError } from "./types";
+
+type Expiration =
+  | {
+      at_height: number;
+    }
+  | {
+      at_time: string;
+    }
+  | {
+      never: {};
+    };
+interface Approval {
+  expires: Expiration;
+  spender: string;
+}
+interface OwnerOfResponse {
+  approvals: Approval[];
+  owner: string;
+}
+
+interface NftInfoResponse {
+  extension?: {
+    image?: string;
+    image_uri?: string;
+    image_url?: string;
+  } | null;
+  token_uri?: string | null;
+}
+
+export const getOwner = async (
+  client: CosmWasmClient,
+  collectionAddress: string,
+  tokenId: string
+): Promise<OwnerOfResponse> =>
+  await client.queryContractSmart(collectionAddress, {
+    owner_of: {
+      token_id: tokenId,
+    },
+  });
+
+export const getImageUrl = async (
+  client: CosmWasmClient,
+  collectionAddress: string,
+  tokenId: string
+): Promise<string | undefined> => {
+  // Get token info.
+  let info: NftInfoResponse;
+  try {
+    info = await client.queryContractSmart(collectionAddress, {
+      nft_info: {
+        token_id: tokenId,
+      },
+    });
+  } catch (err) {
+    console.error(err);
+    throw new VerificationError(
+      500,
+      "Unexpected error retrieving NFT info from chain.",
+      err
+    );
+  }
+
+  // If NFT has extension with image, we're satisfied. Check `image`,
+  // `image_uri`, and `image_url`.
+  if (
+    "extension" in info &&
+    info.extension &&
+    "image" in info.extension &&
+    info.extension.image
+  ) {
+    return info.extension.image;
+  }
+  if (
+    "extension" in info &&
+    info.extension &&
+    "image_uri" in info.extension &&
+    info.extension.image_uri
+  ) {
+    return info.extension.image_uri;
+  }
+  if (
+    "extension" in info &&
+    info.extension &&
+    "image_url" in info.extension &&
+    info.extension.image_url
+  ) {
+    return info.extension.image_url;
+  }
+
+  // Check token URI data.
+  let imageUrl: string | undefined;
+  if ("token_uri" in info && info.token_uri) {
+    try {
+      // Transform IPFS url if necessary.
+      const response = await fetch(
+        transformIpfsUrlToHttpsIfNecessary(info.token_uri)
+      );
+      const data = await response.text();
+
+      // Only try to parse if there's a good chance this is JSON, the heuristic
+      // being the first non-whitespace character is a "{".
+      if (data.trimStart().startsWith("{")) {
+        try {
+          const json = JSON.parse(data);
+          if (typeof json.image === "string" && !!json.image) {
+            imageUrl = json.image;
+          }
+        } catch (err) {
+          console.error(err);
+          throw new VerificationError(
+            415,
+            "Invalid NFT data.",
+            "Failed to parse token_uri data as JSON."
+          );
+        }
+      } else {
+        // If not JSON, hope token_uri is an image.
+        imageUrl = info.token_uri;
+      }
+    } catch (err) {
+      // If error already handled, pass up the chain.
+      if (err instanceof VerificationError) {
+        throw err;
+      }
+
+      console.error(err);
+      throw new VerificationError(
+        500,
+        "Unexpected error retrieving token_uri data.",
+        err
+      );
+    }
+  }
+
+  return imageUrl;
+};
+
+// Use Stargaze's IPFS gateway.
+const transformIpfsUrlToHttpsIfNecessary = (ipfsUrl: string) =>
+  ipfsUrl.startsWith("ipfs://")
+    ? ipfsUrl.replace("ipfs://", "https://ipfs.stargaze.zone/ipfs/")
+    : ipfsUrl;

--- a/src/cw721.ts
+++ b/src/cw721.ts
@@ -58,31 +58,18 @@ export const getImageUrl = async (
     }
   );
 
-  // If NFT has extension with image, we're satisfied. Check `image`,
+  // If NFT has extension with image, we're satisfied. Checks `image`,
   // `image_uri`, and `image_url`.
-  if (
-    "extension" in info &&
-    info.extension &&
-    "image" in info.extension &&
-    info.extension.image
-  ) {
-    return info.extension.image;
-  }
-  if (
-    "extension" in info &&
-    info.extension &&
-    "image_uri" in info.extension &&
-    info.extension.image_uri
-  ) {
-    return info.extension.image_uri;
-  }
-  if (
-    "extension" in info &&
-    info.extension &&
-    "image_url" in info.extension &&
-    info.extension.image_url
-  ) {
-    return info.extension.image_url;
+  if ("extension" in info && info.extension) {
+    if ("image" in info.extension && info.extension.image) {
+      return info.extension.image;
+    }
+    if ("image_uri" in info.extension && info.extension.image_uri) {
+      return info.extension.image_uri;
+    }
+    if ("image_url" in info.extension && info.extension.image_url) {
+      return info.extension.image_url;
+    }
   }
 
   // Check token URI data.

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,0 +1,31 @@
+export class KnownError extends Error {
+  errorString?: string;
+
+  constructor(
+    public statusCode: number,
+    public label: string,
+    error?: unknown
+  ) {
+    super(label);
+    this.name = "HandledError";
+    if (error) {
+      this.errorString = error instanceof Error ? error.message : `${error}`;
+    }
+  }
+
+  get responseJson() {
+    return {
+      error: this.label,
+      ...(this.errorString && {
+        message: this.errorString,
+      }),
+    };
+  }
+}
+
+export class NotOwnerError extends Error {
+  constructor() {
+    super();
+    this.name = "NotOwnerError";
+  }
+}

--- a/src/error.ts
+++ b/src/error.ts
@@ -7,7 +7,7 @@ export class KnownError extends Error {
     error?: unknown
   ) {
     super(label);
-    this.name = "HandledError";
+    this.name = "KnownError";
     if (error) {
       this.errorString = error instanceof Error ? error.message : `${error}`;
     }

--- a/src/error.ts
+++ b/src/error.ts
@@ -16,9 +16,7 @@ export class KnownError extends Error {
   get responseJson() {
     return {
       error: this.label,
-      ...(this.errorString && {
-        message: this.errorString,
-      }),
+      message: this.errorString || this.label,
     };
   }
 }

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,5 +1,5 @@
 export class KnownError extends Error {
-  errorString?: string;
+  errorString: string;
 
   constructor(
     public statusCode: number,
@@ -8,15 +8,13 @@ export class KnownError extends Error {
   ) {
     super(label);
     this.name = "KnownError";
-    if (error) {
-      this.errorString = error instanceof Error ? error.message : `${error}`;
-    }
+    this.errorString = error instanceof Error ? error.message : `${error}`;
   }
 
   get responseJson() {
     return {
       error: this.label,
-      message: this.errorString || this.label,
+      message: this.errorString,
     };
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,7 +190,7 @@ router.post("/:publicKey", async (request, env: Env) => {
         !requestBody.profile.nft.collectionAddress ||
         !("tokenId" in requestBody.profile.nft) ||
         // tokenId could be an empty string, so only perform a typecheck here.
-        typeof requestBody.profile.nft !== "string")
+        typeof requestBody.profile.nft.tokenId !== "string")
     ) {
       throw new Error("NFT needs chainId, collectionAddress, and tokenId.");
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,9 +9,8 @@ import {
   UpdateProfileResponse,
   UpdateProfileRequest,
   Env,
-  VerificationError,
-  NotOwnerError,
 } from "./types";
+import { KnownError, NotOwnerError } from "./error";
 import { verifySecp256k1Signature } from "./utils";
 
 const EMPTY_PROFILE = {
@@ -94,7 +93,7 @@ router.get("/:publicKey", async (request, env: Env) => {
       nft.tokenId
     );
   } catch (err) {
-    if (err instanceof VerificationError) {
+    if (err instanceof KnownError) {
       return respond(400, err.responseJson);
     }
 
@@ -292,7 +291,7 @@ router.post("/:publicKey", async (request, env: Env) => {
       }
 
       // If already handled, respond with specific error.
-      if (err instanceof VerificationError) {
+      if (err instanceof KnownError) {
         return respond(err.statusCode, err.responseJson);
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ router.get("/:publicKey", async (request, env: Env) => {
   const publicKey = request.params?.publicKey?.trim();
   if (!publicKey) {
     return respond(400, {
-      error: "Invalid request.",
+      error: "Invalid request",
       message: "Missing publicKey.",
     });
   }
@@ -66,7 +66,7 @@ router.get("/:publicKey", async (request, env: Env) => {
     console.error("Profile retrieval or parsing", err);
 
     return respond(500, {
-      error: "Failed to retrieve or parse profile.",
+      error: "Failed to retrieve or parse profile",
       message: err instanceof Error ? err.message : `${err}`,
     });
   }
@@ -105,7 +105,7 @@ router.get("/:publicKey", async (request, env: Env) => {
     // chainNftImageUrl remains undefined, which is handled below.
     if (!(err instanceof NotOwnerError)) {
       return respond(500, {
-        error: "Unexpected verification error.",
+        error: "Unexpected verification error",
         message: err instanceof Error ? err.message : `${err}`,
       });
     }
@@ -143,7 +143,7 @@ router.post("/:publicKey", async (request, env: Env) => {
   const publicKey = request.params?.publicKey?.trim();
   if (!publicKey) {
     return respond(400, {
-      error: "Invalid request.",
+      error: "Invalid request",
       message: "Missing publicKey.",
     });
   }
@@ -214,7 +214,7 @@ router.post("/:publicKey", async (request, env: Env) => {
     console.error("Parsing request body", err);
 
     return respond(400, {
-      error: "Invalid body.",
+      error: "Invalid body",
       message: err instanceof Error ? err.message : `${err}`,
     });
   }
@@ -230,7 +230,7 @@ router.post("/:publicKey", async (request, env: Env) => {
     console.error("Profile retrieval or parsing", err);
 
     return respond(500, {
-      error: "Failed to retrieve or parse existing profile.",
+      error: "Failed to retrieve or parse existing profile",
       message: err instanceof Error ? err.message : `${err}`,
     });
   }
@@ -238,7 +238,7 @@ router.post("/:publicKey", async (request, env: Env) => {
   // Validate nonce to prevent replay attacks.
   if (requestBody.profile.nonce !== existingProfile.nonce) {
     return respond(401, {
-      error: "Invalid body.",
+      error: "Invalid body",
       message: `Invalid nonce. Expected: ${existingProfile.nonce}`,
     });
   }
@@ -278,7 +278,7 @@ router.post("/:publicKey", async (request, env: Env) => {
     console.error("Signature verification", err);
 
     return respond(400, {
-      error: "Signature verification failed.",
+      error: "Signature verification failed",
       message: err instanceof Error ? err.message : `${err}`,
     });
   }
@@ -295,7 +295,7 @@ router.post("/:publicKey", async (request, env: Env) => {
         NAME_TAKEN_VALUE;
       if (nameTaken) {
         return respond(500, {
-          error: "Invalid name.",
+          error: "Invalid name",
           message: "Name already exists.",
         });
       }
@@ -303,7 +303,7 @@ router.post("/:publicKey", async (request, env: Env) => {
       console.error("Name uniqueness retrieval", err);
 
       return respond(500, {
-        error: "Failed to check name uniqueness.",
+        error: "Failed to check name uniqueness",
         message: err instanceof Error ? err.message : `${err}`,
       });
     }
@@ -324,14 +324,14 @@ router.post("/:publicKey", async (request, env: Env) => {
       if (!imageUrl) {
         throw new KnownError(
           415,
-          "Invalid NFT image.",
+          "Invalid NFT image",
           "Failed to retrieve image from NFT."
         );
       }
     } catch (err) {
       if (err instanceof NotOwnerError) {
         return respond(401, {
-          error: "Unauthorized.",
+          error: "Unauthorized",
           message: "You do not own this NFT.",
         });
       }
@@ -342,7 +342,7 @@ router.post("/:publicKey", async (request, env: Env) => {
       }
 
       return respond(500, {
-        error: "Unexpected ownership verification error.",
+        error: "Unexpected ownership verification error",
         message: err instanceof Error ? err.message : `${err}`,
       });
     }
@@ -385,7 +385,7 @@ router.post("/:publicKey", async (request, env: Env) => {
     console.error("Profile save", err);
 
     return respond(500, {
-      error: "Failed to save profile.",
+      error: "Failed to save profile",
       message: err instanceof Error ? err.message : `${err}`,
     });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,7 @@ router.get("/:publicKey", async (request, env: Env) => {
       chainId: nft.chainId,
       collectionAddress: nft.collectionAddress,
       tokenId: nft.tokenId,
-      imageUrl: imageUrl,
+      imageUrl,
     };
   } else {
     // Otherwise unset NFT from this address since they no longer own it.

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,6 +158,7 @@ router.post("/:publicKey", async (request, env: Env) => {
     ) {
       throw new Error("Missing profile.nonce.");
     }
+    // Only validate name if truthy, since it can be set to null to clear it.
     if (
       "name" in requestBody.profile &&
       typeof requestBody.profile.name === "string" &&
@@ -172,6 +173,8 @@ router.post("/:publicKey", async (request, env: Env) => {
     ) {
       throw new Error("Name cannot be longer than 32 characters.");
     }
+    // Only validate NFT properties if truthy, since it can be set to null to
+    // clear it.
     if (
       "nft" in requestBody.profile &&
       requestBody.profile.nft &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,10 +149,13 @@ router.post("/:publicKey", async (request, env: Env) => {
     if (!requestBody) {
       throw new Error("Missing.");
     }
-    if (!("profile" in requestBody)) {
+    if (!("profile" in requestBody) || !requestBody.profile) {
       throw new Error("Missing profile.");
     }
-    if (!requestBody.profile || !("nonce" in requestBody.profile)) {
+    if (
+      !("nonce" in requestBody.profile) ||
+      typeof requestBody.profile.nonce !== "number"
+    ) {
       throw new Error("Missing profile.nonce.");
     }
     if (
@@ -168,6 +171,19 @@ router.post("/:publicKey", async (request, env: Env) => {
       requestBody.profile.name.trim().length > 32
     ) {
       throw new Error("Name cannot be longer than 32 characters.");
+    }
+    if (
+      "nft" in requestBody.profile &&
+      requestBody.profile.nft &&
+      (!("chainId" in requestBody.profile.nft) ||
+        !requestBody.profile.nft.chainId ||
+        !("collectionAddress" in requestBody.profile.nft) ||
+        !requestBody.profile.nft.collectionAddress ||
+        !("tokenId" in requestBody.profile.nft) ||
+        // tokenId could be an empty string, so only perform a typecheck here.
+        typeof requestBody.profile.nft !== "string")
+    ) {
+      throw new Error("NFT needs chainId, collectionAddress, and tokenId.");
     }
     if (!("signature" in requestBody)) {
       throw new Error("Missing signature.");

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,8 +12,8 @@ export interface Profile {
 
 export interface ProfileNft {
   chainId: string;
-  tokenId: string;
   collectionAddress: string;
+  tokenId: string;
 }
 
 // Body of fetch profile response.
@@ -42,7 +42,7 @@ export type UpdateProfileResponse =
     }
   | {
       error: string;
-      message?: string;
+      message: string;
     };
 
 // Throws NotOwnerError if wallet does not own NFT or other more specific errors

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,12 +45,6 @@ export type UpdateProfileResponse =
       message?: string;
     };
 
-export interface Nft {
-  collectionAddress: string;
-  tokenId: string;
-  imageUrl: string;
-}
-
 // Throws NotOwnerError if wallet does not own NFT or other more specific errors
 // if failed to retrieve image data.
 export type GetOwnedNftImageUrlFunction = (

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,12 +51,13 @@ export interface Nft {
   imageUrl: string;
 }
 
-// Returns null if wallet does not own NFT or image could not be found.
+// Throws NotOwnerError if wallet does not own NFT or other more specific errors
+// if image data is invalid.
 export type GetOwnedNftImageUrlFunction = (
   publicKey: string,
   collectionAddress: string,
   tokenId: string
-) => Promise<string | null>;
+) => Promise<string>;
 
 export class VerificationError extends Error {
   errorString?: string;
@@ -76,5 +77,12 @@ export class VerificationError extends Error {
         message: this.errorString,
       }),
     };
+  }
+}
+
+export class NotOwnerError extends Error {
+  constructor() {
+    super();
+    this.name = "NotOwnerError";
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,9 +52,9 @@ export interface Nft {
 }
 
 // Throws NotOwnerError if wallet does not own NFT or other more specific errors
-// if image data is invalid.
+// if failed to retrieve image data.
 export type GetOwnedNftImageUrlFunction = (
   publicKey: string,
   collectionAddress: string,
   tokenId: string
-) => Promise<string>;
+) => Promise<string | undefined>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,31 +58,3 @@ export type GetOwnedNftImageUrlFunction = (
   collectionAddress: string,
   tokenId: string
 ) => Promise<string>;
-
-export class VerificationError extends Error {
-  errorString?: string;
-
-  constructor(public statusCode: number, public label: string, error?: unknown) {
-    super(label);
-    this.name = "VerificationError";
-    if (error) {
-      this.errorString = error instanceof Error ? error.message : `${error}`;
-    }
-  }
-
-  get responseJson() {
-    return {
-      error: this.label,
-      ...(this.errorString && {
-        message: this.errorString,
-      }),
-    };
-  }
-}
-
-export class NotOwnerError extends Error {
-  constructor() {
-    super();
-    this.name = "NotOwnerError";
-  }
-}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,3 +51,9 @@ export const verifySecp256k1Signature = async (
 
   return await Secp256k1.verifySignature(signature, messageHash, publicKeyData);
 };
+
+// Use Stargaze's IPFS gateway.
+export const transformIpfsUrlToHttpsIfNecessary = (ipfsUrl: string) =>
+  ipfsUrl.startsWith("ipfs://")
+    ? ipfsUrl.replace("ipfs://", "https://ipfs.stargaze.zone/ipfs/")
+    : ipfsUrl;


### PR DESCRIPTION
This adds support for cw721s on Juno, as well as implements a basic architecture for supporting multiple NFT sources (likely chains or markets).

I also realized we were not verifying ownership on save/update, which was fine because we do on retrieval, but we might as well do both (especially if it's an easy to use generic function).

This also adds a cap of 32 characters for names, to prevent spam.