### PR TITLE
Use indexer to speed up juno cw721 validation

### DIFF
--- a/src/chains/cw721.ts
+++ b/src/chains/cw721.ts
@@ -1,11 +1,10 @@
 import { CosmWasmClient } from "@cosmjs/cosmwasm-stargate";
 import { GetOwnedNftImageUrlFunction } from "../types";
 import { KnownError, NotOwnerError } from "../error";
-import { secp256k1PublicKeyToBech32Address } from "../utils";
 import * as Cw721 from "../cw721";
 
 export const getOwnedNftImageUrl = (rpc: string, walletAddress: string): GetOwnedNftImageUrlFunction => async (
-  publicKey,
+  _,
   collectionAddress,
   tokenId
 ) => {

--- a/src/cw721.ts
+++ b/src/cw721.ts
@@ -58,6 +58,12 @@ export const getImageUrl = async (
     }
   );
 
+  return await getImageUrlFromInfo(info);
+};
+
+export const getImageUrlFromInfo = async (
+  info: NftInfoResponse
+): Promise<string | undefined> => {
   // If NFT has extension with image, we're satisfied. Checks `image`,
   // `image_uri`, and `image_url`.
   if ("extension" in info && info.extension) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,10 +54,10 @@ export const verifySecp256k1Signature = async (
   return await Secp256k1.verifySignature(signature, messageHash, publicKeyData);
 };
 
-// Use Stargaze's IPFS gateway.
+// Use NFT.Storage's IPFS gateway.
 export const transformIpfsUrlToHttpsIfNecessary = (ipfsUrl: string) =>
   ipfsUrl.startsWith("ipfs://")
-    ? ipfsUrl.replace("ipfs://", "https://ipfs.stargaze.zone/ipfs/")
+    ? ipfsUrl.replace("ipfs://", "https://nftstorage.link/ipfs/")
     : ipfsUrl;
 
 export const EMPTY_PROFILE = {


### PR DESCRIPTION
This uses the DAO DAO indexer to speed up juno cw721 validation, since it verifies ownership on every fetch request.