### PR TITLE
Ignore case for global uniqueness

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -67,7 +67,8 @@ export const EMPTY_PROFILE = {
 };
 
 export const getProfileKey = (publicKey: string) => `profile:${publicKey}`;
-export const getNameTakenKey = (name: string) => `nameTaken:${name}`;
+export const getNameTakenKey = (name: string) =>
+  `nameTaken:${name.toLowerCase()}`;
 
 export const getOwnedNftWithImage = async (
   publicKey: string,


### PR DESCRIPTION
This makes it so that if I reserve the name `noah`, no one can choose a differently-cased name, like `Noah`.