### PR TITLE
Support NFTs staked with DAOs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "pfpk",
       "version": "0.0.1",
       "dependencies": {
-        "@apollo/client": "^3.7.1",
         "@cosmjs/amino": "^0.29.0",
         "@cosmjs/cosmwasm-stargate": "^0.29.0",
         "@cosmjs/crypto": "^0.29.0",
@@ -22,55 +21,6 @@
         "@cloudflare/workers-types": "^3.16.0",
         "@types/crypto-js": "^4.1.1",
         "wrangler": "2.1.10"
-      }
-    },
-    "node_modules/@apollo/client": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.7.1.tgz",
-      "integrity": "sha512-xu5M/l7p9gT9Fx7nF3AQivp0XukjB7TM7tOd5wifIpI8RskYveL4I+rpTijzWrnqCPZabkbzJKH7WEAKdctt9w==",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@wry/context": "^0.7.0",
-        "@wry/equality": "^0.5.0",
-        "@wry/trie": "^0.3.0",
-        "graphql-tag": "^2.12.6",
-        "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.16.1",
-        "prop-types": "^15.7.2",
-        "response-iterator": "^0.2.6",
-        "symbol-observable": "^4.0.0",
-        "ts-invariant": "^0.10.3",
-        "tslib": "^2.3.0",
-        "zen-observable-ts": "^1.2.5"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0",
-        "graphql-ws": "^5.5.5",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
-      },
-      "peerDependenciesMeta": {
-        "graphql-ws": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "subscriptions-transport-ws": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@apollo/client/node_modules/symbol-observable": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
-      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -281,14 +231,6 @@
       },
       "peerDependencies": {
         "esbuild": "*"
-      }
-    },
-    "node_modules/@graphql-typed-document-node/core": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
-      "integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==",
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/@iarna/toml": {
@@ -647,39 +589,6 @@
       "resolved": "https://registry.npmjs.org/@types/stack-trace/-/stack-trace-0.0.29.tgz",
       "integrity": "sha512-TgfOX+mGY/NyNxJLIbDWrO9DjGoVSW9+aB8H2yy1fy32jsvxijhmyJI9fDFgvz3YP4lvJaq9DzdR/M1bOgVc9g==",
       "dev": true
-    },
-    "node_modules/@wry/context": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.0.tgz",
-      "integrity": "sha512-LcDAiYWRtwAoSOArfk7cuYvFXytxfVrdX7yxoUmK7pPITLk5jYh2F8knCwS7LjgYL8u1eidPlKKV6Ikqq0ODqQ==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@wry/equality": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.3.tgz",
-      "integrity": "sha512-avR+UXdSrsF2v8vIqIgmeTY0UR91UT+IyablCyKe/uk22uOJ8fusKZnH9JH9e1/EtLeNJBtagNmL3eJdnOV53g==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@wry/trie": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.2.tgz",
-      "integrity": "sha512-yRTyhWSls2OY/pYLfwff867r8ekooZ4UI+/gxot5Wj8EFwSf2rG+n+Mo/6LoLQm1TKA4GRj2+LCpbfS937dClQ==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/anymatch": {
       "version": "3.1.2",
@@ -1408,20 +1317,6 @@
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
-    "node_modules/graphql-tag": {
-      "version": "2.12.6",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
-      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -1472,14 +1367,6 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dependencies": {
-        "react-is": "^16.7.0"
       }
     },
     "node_modules/html-rewriter-wasm": {
@@ -1586,11 +1473,6 @@
       "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-2.6.6.tgz",
       "integrity": "sha512-hIPHtXGymCX7Lzb2I4G6JgZFE4QEEQwst9GORK7sMYUpJvLfy4yZJr95r04e8DzoAnj6HcxM2m4TbK+juu+18g=="
     },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -1617,17 +1499,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -1819,14 +1690,6 @@
         "validate-npm-package-name": "^4.0.0"
       }
     },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -1848,26 +1711,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/optimism": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
-      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
-      "dependencies": {
-        "@wry/context": "^0.6.0",
-        "@wry/trie": "^0.3.0"
-      }
-    },
-    "node_modules/optimism/node_modules/@wry/context": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.1.tgz",
-      "integrity": "sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/pako": {
@@ -1908,16 +1751,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
     "node_modules/protobufjs": {
       "version": "6.11.3",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
@@ -1943,11 +1776,6 @@
         "pbts": "bin/pbts"
       }
     },
-    "node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -1964,14 +1792,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/readonly-date/-/readonly-date-1.0.0.tgz",
       "integrity": "sha512-tMKIV7hlk0h4mO3JTmmVuIlJVXjKk3Sep9Bf5OH0O+758ruuVkUy2J9SttDLm91IEX/WHlXPSpxMGjPj4beMIQ=="
-    },
-    "node_modules/response-iterator": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/response-iterator/-/response-iterator-0.2.6.tgz",
-      "integrity": "sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==",
-      "engines": {
-        "node": ">=0.8"
-      }
     },
     "node_modules/rollup-plugin-inject": {
       "version": "3.0.2",
@@ -2156,22 +1976,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/ts-invariant": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
-      "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-    },
     "node_modules/undici": {
       "version": "5.9.1",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.9.1.tgz",
@@ -2299,49 +2103,9 @@
         "mustache": "^4.2.0",
         "stack-trace": "0.0.10"
       }
-    },
-    "node_modules/zen-observable": {
-      "version": "0.8.15",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
-      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
-    },
-    "node_modules/zen-observable-ts": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
-      "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
-      "dependencies": {
-        "zen-observable": "0.8.15"
-      }
     }
   },
   "dependencies": {
-    "@apollo/client": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.7.1.tgz",
-      "integrity": "sha512-xu5M/l7p9gT9Fx7nF3AQivp0XukjB7TM7tOd5wifIpI8RskYveL4I+rpTijzWrnqCPZabkbzJKH7WEAKdctt9w==",
-      "requires": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@wry/context": "^0.7.0",
-        "@wry/equality": "^0.5.0",
-        "@wry/trie": "^0.3.0",
-        "graphql-tag": "^2.12.6",
-        "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.16.1",
-        "prop-types": "^15.7.2",
-        "response-iterator": "^0.2.6",
-        "symbol-observable": "^4.0.0",
-        "ts-invariant": "^0.10.3",
-        "tslib": "^2.3.0",
-        "zen-observable-ts": "^1.2.5"
-      },
-      "dependencies": {
-        "symbol-observable": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
-          "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ=="
-        }
-      }
-    },
     "@cloudflare/kv-asset-handler": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.2.0.tgz",
@@ -2534,12 +2298,6 @@
         "escape-string-regexp": "^4.0.0",
         "rollup-plugin-node-polyfills": "^0.2.1"
       }
-    },
-    "@graphql-typed-document-node/core": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
-      "integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==",
-      "requires": {}
     },
     "@iarna/toml": {
       "version": "2.2.5",
@@ -2837,30 +2595,6 @@
       "resolved": "https://registry.npmjs.org/@types/stack-trace/-/stack-trace-0.0.29.tgz",
       "integrity": "sha512-TgfOX+mGY/NyNxJLIbDWrO9DjGoVSW9+aB8H2yy1fy32jsvxijhmyJI9fDFgvz3YP4lvJaq9DzdR/M1bOgVc9g==",
       "dev": true
-    },
-    "@wry/context": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.0.tgz",
-      "integrity": "sha512-LcDAiYWRtwAoSOArfk7cuYvFXytxfVrdX7yxoUmK7pPITLk5jYh2F8knCwS7LjgYL8u1eidPlKKV6Ikqq0ODqQ==",
-      "requires": {
-        "tslib": "^2.3.0"
-      }
-    },
-    "@wry/equality": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.3.tgz",
-      "integrity": "sha512-avR+UXdSrsF2v8vIqIgmeTY0UR91UT+IyablCyKe/uk22uOJ8fusKZnH9JH9e1/EtLeNJBtagNmL3eJdnOV53g==",
-      "requires": {
-        "tslib": "^2.3.0"
-      }
-    },
-    "@wry/trie": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.2.tgz",
-      "integrity": "sha512-yRTyhWSls2OY/pYLfwff867r8ekooZ4UI+/gxot5Wj8EFwSf2rG+n+Mo/6LoLQm1TKA4GRj2+LCpbfS937dClQ==",
-      "requires": {
-        "tslib": "^2.3.0"
-      }
     },
     "anymatch": {
       "version": "3.1.2",
@@ -3295,14 +3029,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
       "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw=="
     },
-    "graphql-tag": {
-      "version": "2.12.6",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
-      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
-      "requires": {
-        "tslib": "^2.1.0"
-      }
-    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -3341,14 +3067,6 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
-    "hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "requires": {
-        "react-is": "^16.7.0"
       }
     },
     "html-rewriter-wasm": {
@@ -3432,11 +3150,6 @@
       "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-2.6.6.tgz",
       "integrity": "sha512-hIPHtXGymCX7Lzb2I4G6JgZFE4QEEQwst9GORK7sMYUpJvLfy4yZJr95r04e8DzoAnj6HcxM2m4TbK+juu+18g=="
     },
-    "js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-    },
     "kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -3460,14 +3173,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-    },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      }
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -3597,11 +3302,6 @@
         "validate-npm-package-name": "^4.0.0"
       }
     },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
-    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -3614,25 +3314,6 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^4.0.0"
-      }
-    },
-    "optimism": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
-      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
-      "requires": {
-        "@wry/context": "^0.6.0",
-        "@wry/trie": "^0.3.0"
-      },
-      "dependencies": {
-        "@wry/context": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.1.tgz",
-          "integrity": "sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==",
-          "requires": {
-            "tslib": "^2.3.0"
-          }
-        }
       }
     },
     "pako": {
@@ -3664,16 +3345,6 @@
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
-    "prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "requires": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
     "protobufjs": {
       "version": "6.11.3",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
@@ -3694,11 +3365,6 @@
         "long": "^4.0.0"
       }
     },
-    "react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
     "readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -3712,11 +3378,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/readonly-date/-/readonly-date-1.0.0.tgz",
       "integrity": "sha512-tMKIV7hlk0h4mO3JTmmVuIlJVXjKk3Sep9Bf5OH0O+758ruuVkUy2J9SttDLm91IEX/WHlXPSpxMGjPj4beMIQ=="
-    },
-    "response-iterator": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/response-iterator/-/response-iterator-0.2.6.tgz",
-      "integrity": "sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw=="
     },
     "rollup-plugin-inject": {
       "version": "3.0.2",
@@ -3860,19 +3521,6 @@
         "is-number": "^7.0.0"
       }
     },
-    "ts-invariant": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
-      "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
-      "requires": {
-        "tslib": "^2.1.0"
-      }
-    },
-    "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-    },
     "undici": {
       "version": "5.9.1",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.9.1.tgz",
@@ -3964,19 +3612,6 @@
         "cookie": "^0.4.1",
         "mustache": "^4.2.0",
         "stack-trace": "0.0.10"
-      }
-    },
-    "zen-observable": {
-      "version": "0.8.15",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
-      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
-    },
-    "zen-observable-ts": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
-      "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
-      "requires": {
-        "zen-observable": "0.8.15"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "wrangler": "2.1.10"
   },
   "dependencies": {
-    "@apollo/client": "^3.7.1",
     "@cosmjs/amino": "^0.29.0",
     "@cosmjs/cosmwasm-stargate": "^0.29.0",
     "@cosmjs/crypto": "^0.29.0",

--- a/src/chains/cw721.ts
+++ b/src/chains/cw721.ts
@@ -23,8 +23,9 @@ export const getOwnedNftImageUrl =
           const addressStakedToken =
             await DaoVotingCw721Staked.addressStakedToken(
               client,
+              // Owner is the staking contract.
               owner,
-              collectionAddress,
+              walletAddress,
               tokenId
             );
 

--- a/src/chains/cw721.ts
+++ b/src/chains/cw721.ts
@@ -2,36 +2,54 @@ import { CosmWasmClient } from "@cosmjs/cosmwasm-stargate";
 import { GetOwnedNftImageUrlFunction } from "../types";
 import { KnownError, NotOwnerError } from "../error";
 import * as Cw721 from "../cw721";
+import * as DaoVotingCw721Staked from "../daoVotingCw721Staked";
 
-export const getOwnedNftImageUrl = (rpc: string, walletAddress: string): GetOwnedNftImageUrlFunction => async (
-  _,
-  collectionAddress,
-  tokenId
-) => {
-  let imageUrl: string | undefined;
-  try {
-    const client = await CosmWasmClient.connect(rpc);
+export const getOwnedNftImageUrl =
+  (rpc: string, walletAddress: string): GetOwnedNftImageUrlFunction =>
+  async (_, collectionAddress, tokenId) => {
+    let imageUrl: string | undefined;
+    try {
+      const client = await CosmWasmClient.connect(rpc);
 
-    const owner = await Cw721.getOwner(client, collectionAddress, tokenId);
-    // If does not own NFT, throw error.
-    if (owner.owner !== walletAddress) {
-      throw new NotOwnerError();
+      const owner = await Cw721.getOwner(client, collectionAddress, tokenId);
+      // If wallet does not directly own NFT, check if staked with a DAO voting
+      // module.
+      if (owner !== walletAddress) {
+        const isStakingContract = await DaoVotingCw721Staked.isContract(
+          client,
+          owner
+        );
+        if (isStakingContract) {
+          const addressStakedToken =
+            await DaoVotingCw721Staked.addressStakedToken(
+              client,
+              owner,
+              collectionAddress,
+              tokenId
+            );
+
+          if (!addressStakedToken) {
+            throw new NotOwnerError();
+          }
+        } else {
+          throw new NotOwnerError();
+        }
+      }
+
+      imageUrl = await Cw721.getImageUrl(client, collectionAddress, tokenId);
+    } catch (err) {
+      // If error already handled, pass up the chain.
+      if (err instanceof KnownError || err instanceof NotOwnerError) {
+        throw err;
+      }
+
+      console.error(err);
+      throw new KnownError(
+        500,
+        "Unexpected error retrieving NFT info from chain",
+        err
+      );
     }
 
-    imageUrl = await Cw721.getImageUrl(client, collectionAddress, tokenId);
-  } catch (err) {
-    // If error already handled, pass up the chain.
-    if (err instanceof KnownError || err instanceof NotOwnerError) {
-      throw err;
-    }
-
-    console.error(err);
-    throw new KnownError(
-      500,
-      "Unexpected error retrieving NFT info from chain",
-      err
-    );
-  }
-
-  return imageUrl;
-};
+    return imageUrl;
+  };

--- a/src/chains/juno.ts
+++ b/src/chains/juno.ts
@@ -1,38 +1,9 @@
 import { GetOwnedNftImageUrlFunction } from "../types";
-import { KnownError, NotOwnerError } from "../error";
+import { KnownError } from "../error";
 import { secp256k1PublicKeyToBech32Address } from "../utils";
-import { ApolloClient, InMemoryCache, gql } from "@apollo/client/core";
 import { getOwnedNftImageUrl as makeCw721GetOwnedNftImageUrl } from "./cw721";
-import { getImageUrlFromInfo } from "../cw721";
-
-const INDEXER_API_TEMPLATE =
-  "https://indexer-mainnet.daodao.zone/contract/{{collectionAddress}}/cw721/allNftInfo?tokenId={{tokenId}}";
 
 const JUNO_RPC = "https://rpc.juno.strange.love:443";
-const LOOP_API_TEMPLATE = "https://nft-juno-backend.loop.markets";
-
-// Graph Query Language: https://www.apollographql.com/docs/react/data/queries/
-const GET_LOOP_NFTS_QUERY = gql`
-  query GetLoopNfts($walletAddress: String!) {
-    nfts(filter: { owner: { equalTo: $walletAddress } }) {
-      nodes {
-        contractId
-        tokenID
-        image
-      }
-    }
-  }
-`;
-
-interface LoopQuery {
-  nfts: {
-    nodes: {
-      contractId: string;
-      tokenID: string;
-      image: string | null;
-    }[];
-  };
-}
 
 export const getOwnedNftImageUrl: GetOwnedNftImageUrlFunction = async (
   publicKey,
@@ -47,70 +18,6 @@ export const getOwnedNftImageUrl: GetOwnedNftImageUrlFunction = async (
     throw new KnownError(400, "Invalid public key", err);
   }
 
-  // Check indexer first.
-  try {
-    const indexerEndpoint = INDEXER_API_TEMPLATE.replace(
-      "{{collectionAddress}}",
-      collectionAddress
-    ).replace("{{tokenId}}", tokenId);
-    const indexerResponse = await fetch(indexerEndpoint);
-
-    if (indexerResponse.status === 200) {
-      const {
-        access: { owner },
-        info,
-      } = await indexerResponse.json<{
-        access: { owner: string };
-        info: any;
-      }>();
-
-      if (owner === junoAddress) {
-        return await getImageUrlFromInfo(info);
-      } else {
-        throw new NotOwnerError();
-      }
-    }
-  } catch (err) {
-    console.error(
-      `Error fetching cw721 indexer for ${publicKey}/${collectionAddress}/${tokenId}`,
-      err
-    );
-    // Use fallbacks.
-  }
-
-  try {
-    const apolloClient = new ApolloClient({
-      uri: LOOP_API_TEMPLATE,
-      cache: new InMemoryCache(),
-    });
-
-    // Search Loop API for this address's NFTs. If the desired NFT is not present,
-    // public key does not own it on Loop.
-    const loopQuery = await apolloClient.query<LoopQuery>({
-      query: GET_LOOP_NFTS_QUERY,
-      variables: {
-        walletAddress: junoAddress,
-      },
-    });
-
-    const loopNft = loopQuery.data.nfts.nodes.find(
-      (nft) => nft.contractId === collectionAddress && nft.tokenID === tokenId
-    );
-
-    // If found, return image.
-    if (loopNft?.image) {
-      return loopNft.image;
-    }
-  } catch (err) {
-    console.error(err);
-    throw new KnownError(
-      500,
-      "Unexpected error retrieving NFT info from Loop API",
-      err
-    );
-  }
-
-  // If NFT not found, fallback to checking CW721 contract directly.
   return await makeCw721GetOwnedNftImageUrl(JUNO_RPC, junoAddress)(
     publicKey,
     collectionAddress,

--- a/src/cw721.ts
+++ b/src/cw721.ts
@@ -36,12 +36,14 @@ export const getOwner = async (
   client: CosmWasmClient,
   collectionAddress: string,
   tokenId: string
-): Promise<OwnerOfResponse> =>
-  await client.queryContractSmart(collectionAddress, {
-    owner_of: {
-      token_id: tokenId,
-    },
-  });
+): Promise<string> =>
+  (
+    (await client.queryContractSmart(collectionAddress, {
+      owner_of: {
+        token_id: tokenId,
+      },
+    })) as OwnerOfResponse
+  ).owner;
 
 export const getImageUrl = async (
   client: CosmWasmClient,

--- a/src/daoVotingCw721Staked.ts
+++ b/src/daoVotingCw721Staked.ts
@@ -1,0 +1,59 @@
+import { CosmWasmClient } from "@cosmjs/cosmwasm-stargate";
+
+type InfoResponse = {
+  info: {
+    contract: string;
+    version: string;
+  };
+};
+
+export const isContract = async (
+  client: CosmWasmClient,
+  contractAddress: string
+): Promise<boolean> => {
+  const info: InfoResponse = await client.queryContractSmart(contractAddress, {
+    info: {},
+  });
+
+  return (
+    !!info &&
+    "contract" in info &&
+    info.contract === "crates.io:dao-voting-cw721-staked"
+  );
+};
+
+// Get all NFTs an address has staked and check if the token ID is in the list.
+const LIMIT = 30;
+export const addressStakedToken = async (
+  client: CosmWasmClient,
+  contractAddress: string,
+  address: string,
+  tokenId: string
+): Promise<boolean> => {
+  const tokens: string[] = [];
+  while (true) {
+    const response: string[] = await client.queryContractSmart(
+      contractAddress,
+      {
+        staked_nfts: {
+          address,
+          start_after: tokens[tokens.length - 1],
+          limit: LIMIT,
+        },
+      }
+    );
+
+    if (!response?.length) {
+      break;
+    }
+
+    tokens.push(...response);
+
+    // If we have less than the limit of items, we've exhausted them.
+    if (response.length < LIMIT) {
+      break;
+    }
+  }
+
+  return tokens.includes(tokenId);
+};

--- a/src/daoVotingCw721Staked.ts
+++ b/src/daoVotingCw721Staked.ts
@@ -11,9 +11,12 @@ export const isContract = async (
   client: CosmWasmClient,
   contractAddress: string
 ): Promise<boolean> => {
-  const info: InfoResponse = await client.queryContractSmart(contractAddress, {
-    info: {},
-  });
+  const { info }: InfoResponse = await client.queryContractSmart(
+    contractAddress,
+    {
+      info: {},
+    }
+  );
 
   return (
     !!info &&


### PR DESCRIPTION
Right now, PFPK requires NFTs to be owned by the wallet to select them. However, it is likely that many people will want to use an NFT they have staked with a DAO, using [dao-voting-cw721-staked](https://github.com/DA0-DA0/dao-contracts/tree/main/contracts/voting/dao-voting-cw721-staked).

This PR allows NFTs staked by a wallet with a DAO via this contract to be assigned as if the wallet owned them. Technically the wallet still fully owns the NFT, so this doesn't break any rules.

This PR also removes Loop's API calls since we can just ask the contracts for ownership information. It is not slow.