### PR TITLE
Allow querying profiles via their bech32 address or hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ kv-namespaces = [
 echo <VALUE> | npx wrangler secret put INDEXER_API_KEY
 ```
 
-## Architecture
+## API
 
 ### `GET /:publicKey`
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,13 @@ echo <VALUE> | npx wrangler secret put INDEXER_API_KEY
 
 ### `GET /:publicKey`
 
-`publicKey` is the hexadecimal representation of a public key in the Cosmos.
+`publicKey` is the hexadecimal representation of a secp256k1 public key used in
+the Cosmos.
+
+You can also use the bech32 hash or address to query for the profile:
+
+- `GET /bech32/:bech32Hash`
+- `GET /address/:bech32Address`
 
 The returned type is:
 

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ echo <VALUE> | npx wrangler secret put INDEXER_API_KEY
 `publicKey` is the hexadecimal representation of a secp256k1 public key used in
 the Cosmos.
 
-You can also use the bech32 hash or address to query for the profile:
+You can alternatively use the bech32 address or hash to query for the profile:
 
-- `GET /bech32/:bech32Hash`
 - `GET /address/:bech32Address`
+- `GET /bech32/:bech32Hash`
 
 The returned type is:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,11 +31,11 @@ router.get("/resolve/:bech32Prefix/:name", resolveProfile);
 // Fetch profile.
 router.get("/:publicKey", fetchProfile);
 
-// Fetch profile with bech32 hash.
-router.get("/bech32/:bech32Hash", fetchProfile);
-
 // Fetch profile with bech32 address.
 router.get("/address/:bech32Address", fetchProfile);
+
+// Fetch profile with bech32 hash.
+router.get("/bech32/:bech32Hash", fetchProfile);
 
 // Update profile.
 router.post("/:publicKey", updateProfile);

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,9 @@ router.get("/:publicKey", fetchProfile);
 // Fetch profile with bech32 hash.
 router.get("/bech32/:bech32Hash", fetchProfile);
 
+// Fetch profile with bech32 address.
+router.get("/address/:bech32Address", fetchProfile);
+
 // Update profile.
 router.post("/:publicKey", updateProfile);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,9 @@ router.get("/resolve/:bech32Prefix/:name", resolveProfile);
 // Fetch profile.
 router.get("/:publicKey", fetchProfile);
 
+// Fetch profile with bech32 hash.
+router.get("/bech32/:bech32Hash", fetchProfile);
+
 // Update profile.
 router.post("/:publicKey", updateProfile);
 

--- a/src/routes/resolveProfile.ts
+++ b/src/routes/resolveProfile.ts
@@ -6,7 +6,7 @@ import {
   ResolveProfileResponse,
 } from "../types";
 import {
-  getNameTakenKey,
+  getPublicKeyForNameTakenKey,
   getOwnedNftWithImage,
   getProfileKey,
   secp256k1PublicKeyToBech32Address,
@@ -40,7 +40,7 @@ export const resolveProfile: RouteHandler<Request> = async (
   try {
     let resolved: ProfileSearchHit | null = null;
 
-    const publicKey = await env.PROFILES.get(getNameTakenKey(name));
+    const publicKey = await env.PROFILES.get(getPublicKeyForNameTakenKey(name));
     const profile = publicKey
       ? await env.PROFILES.get<Profile>(getProfileKey(publicKey), "json")
       : undefined;

--- a/src/routes/searchProfiles.ts
+++ b/src/routes/searchProfiles.ts
@@ -6,7 +6,7 @@ import {
   SearchProfilesResponse,
 } from "../types";
 import {
-  getNameTakenKey,
+  getPublicKeyForNameTakenKey,
   getOwnedNftWithImage,
   getProfileKey,
   secp256k1PublicKeyToBech32Address,
@@ -48,7 +48,7 @@ export const searchProfiles: RouteHandler<Request> = async (
     const profileKeys = (
       await env.PROFILES.list<Profile>({
         limit: 5,
-        prefix: getNameTakenKey(namePrefix),
+        prefix: getPublicKeyForNameTakenKey(namePrefix),
       })
     ).keys;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,9 +5,8 @@ import { getOwnedNftImageUrl } from "./chains";
 import { Env, ProfileNft, ProfileNftWithImage } from "./types";
 
 // https://github.com/chainapsis/keplr-wallet/blob/088dc701ce14df77a1ee22b7e39c651e50879d9f/packages/crypto/src/key.ts#L56-L63
-export const secp256k1PublicKeyToBech32Address = (
-  hexPublicKey: string,
-  bech32Prefix: string
+export const secp256k1PublicKeyToBech32HexHash = (
+  hexPublicKey: string
 ): string => {
   // https://github.com/cosmos/cosmos-sdk/blob/e09516f4795c637ab12b30bf732ce5d86da78424/crypto/keys/secp256k1/secp256k1.go#L152-L162
   // Cosmos SDK generates address data using RIPEMD160(SHA256(pubkey)).
@@ -23,9 +22,17 @@ export const secp256k1PublicKeyToBech32Address = (
   );
   const ripemd160Hash = CryptoJS.RIPEMD160(sha256Hash);
 
-  // Output Bech32 formatted address.
-  const addressData = fromHex(ripemd160Hash.toString(CryptoJS.enc.Hex));
-  return toBech32(bech32Prefix, addressData);
+  // Output Bech32 data.
+  const bech32Hash = ripemd160Hash.toString(CryptoJS.enc.Hex);
+  return bech32Hash;
+};
+
+export const secp256k1PublicKeyToBech32Address = (
+  hexPublicKey: string,
+  bech32Prefix: string
+): string => {
+  const addressData = secp256k1PublicKeyToBech32HexHash(hexPublicKey);
+  return toBech32(bech32Prefix, fromHex(addressData));
 };
 
 export const verifySecp256k1Signature = async (
@@ -67,8 +74,11 @@ export const EMPTY_PROFILE = {
 };
 
 export const getProfileKey = (publicKey: string) => `profile:${publicKey}`;
-export const getNameTakenKey = (name: string) =>
+export const getPublicKeyForNameTakenKey = (name: string) =>
   `nameTaken:${name.toLowerCase()}`;
+
+// Map bech32 hash (hex string) to public key to map to profile.
+export const getPublicKeyForBech32HashKey = (bech32Hash: string) => `publicKeyForBech32Hash:${bech32Hash}`;
 
 export const getOwnedNftWithImage = async (
   env: Env,


### PR DESCRIPTION
This PR computes and stores a mapping from the bech32 hash of a secp256k1 public key to the public key itself when a profile is updated, so that the profile can be resolved from either its public key, the bech32 hash of its public key, or the bech32 address. This enables clients to fetch profile information without asking the chain for an address' public key.